### PR TITLE
Fix #2: target decimal formatting is broken in some cultures

### DIFF
--- a/Cli/Cli.csproj
+++ b/Cli/Cli.csproj
@@ -8,8 +8,8 @@
     <RootNamespace>LoopToIosConverter.Cli</RootNamespace>
     <AssemblyName>LoopToIosConverter</AssemblyName>
     <PublishSingleFile>true</PublishSingleFile>
-    <AssemblyVersion>1.0.0</AssemblyVersion>
-    <ProductVersion>1.0.0</ProductVersion>
+    <AssemblyVersion>1.0.1</AssemblyVersion>
+    <ProductVersion>1.0.1</ProductVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Common/IosDataModel/IosHabitFormatter.cs
+++ b/Common/IosDataModel/IosHabitFormatter.cs
@@ -42,7 +42,7 @@ public static class IosHabitFormatter
             habit.CreationTime.ToString(_creationTimeFormat),
             Quoted(habit.Frequency.ToCsvString()),
             Quoted(habit.NotificationSettings?.ToCsvString() ?? string.Empty),
-            habit.Target.ToString("F1"));
+            habit.Target.ToString("F1", CultureInfo.InvariantCulture));
 
         var suffixString = habit switch
         {


### PR DESCRIPTION
In some cultures, decimal number formatting is done using a comma instead of a period. This breaks the csv file structure of the iOS app, causing data loss. This change defines the invariant culture for this data point conversion.